### PR TITLE
Change start/end data type to datetime

### DIFF
--- a/notion/types.py
+++ b/notion/types.py
@@ -752,8 +752,8 @@ class MultiSelectPropertyValue(PropertyValueBase):
 
 
 class StartEndDate(BaseModel):
-    start: date
-    end: Optional[date]
+    start: datetime
+    end: Optional[datetime]
 
 
 class DatePropertyValue(PropertyValueBase):


### PR DESCRIPTION
Start and end data types should be changed to datetime.datetime instead of datetime.date to conform to Notion SDK requirements.