### PR TITLE
Fix file validation

### DIFF
--- a/notion/types.py
+++ b/notion/types.py
@@ -819,11 +819,6 @@ class FileWithName(File, ExternalFile):
     name: str
 
 
-class FilesPropertyValue(PropertyValueBase):
-    type: PropertyValueType = Field(PropertyValueType.FILES, const=True)
-    files: List[Union[FileWithName, ExternalFileWithName]]
-
-
 class CheckboxPropertyValue(PropertyValueBase):
     type: PropertyValueType = Field(PropertyValueType.CHECKBOX, const=True)
     checkbox: bool
@@ -866,6 +861,11 @@ class LastEditedByPropertyValue(PropertyValueBase):
 
 class ExternalFileWithName(ExternalFile):
     name: str
+
+
+class FilesPropertyValue(PropertyValueBase):
+    type: PropertyValueType = Field(PropertyValueType.FILES, const=True)
+    files: List[Union[FileWithName, ExternalFileWithName]]
 
 
 class FilesPropertyInputValue(PropertyValueBase):

--- a/notion/types.py
+++ b/notion/types.py
@@ -821,7 +821,7 @@ class FileWithName(File, ExternalFile):
 
 class FilesPropertyValue(PropertyValueBase):
     type: PropertyValueType = Field(PropertyValueType.FILES, const=True)
-    files: List[FileWithName]
+    files: List[Union[FileWithName, ExternalFileWithName]]
 
 
 class CheckboxPropertyValue(PropertyValueBase):


### PR DESCRIPTION
Improperly flagging properties when they contain external files.  Happens on post but post succeeds. On get query fails completely.